### PR TITLE
Handle 0-arg case

### DIFF
--- a/src/range.test.ts
+++ b/src/range.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, test } from "vitest";
 import { range } from "./range";
 
 describe("range", () => {
+  test("0 arguments: throw", () => {
+    expect(() => {
+      // @ts-expect-error Range requires at least one argument
+      range();
+    }).toThrow("range requires at least one argument");
+  });
+
   test("single positive integer argument: iterates from 0 to arg, step of 1", () => {
     expect([...range(3)]).toEqual([0, 1, 2]);
   });

--- a/src/range.ts
+++ b/src/range.ts
@@ -17,20 +17,14 @@ export function range(start: number, end: number, step: number): Range;
  * Range function implementation
  */
 export function range(...args: number[]): Range {
-  // Parse out start/end/step to handle overload
-  let start = 0,
-    end = 0,
-    step = 1;
-
   if (args.length === 0) {
     throw new Error("range requires at least one argument");
-  } else if (args.length === 1) {
-    end = args[0];
-  } else if (args.length === 2) {
-    [start, end] = args.slice(0, 2);
-  } else {
-    [start, end, step] = args.slice(0, 3);
   }
+
+  // Parse out start/end/step to handle overload
+  const start = args.length > 1 ? args[0] : 0;
+  const end = args.length === 1 ? args[0] : args[1] || 0;
+  const step = args[2] || 1;
 
   // Create a "target" object (that we'll use as proxy target)
   const target = {

--- a/src/range.ts
+++ b/src/range.ts
@@ -19,6 +19,9 @@ export function range(start: number, end: number, step: number): Range;
 export function range(...args: number[]): Range {
   // Parse out start/end/step to handle overload
   const [start, end, step] = (() => {
+    if (args.length === 0) {
+      throw new Error("range requires at least one argument");
+    }
     if (args.length === 1) {
       return [0, args[0], 1];
     }

--- a/src/range.ts
+++ b/src/range.ts
@@ -23,8 +23,8 @@ export function range(...args: number[]): Range {
 
   // Parse out start/end/step to handle overload
   const start = args.length > 1 ? args[0] : 0;
-  const end = args.length === 1 ? args[0] : args[1] || 0;
-  const step = args[2] || 1;
+  const end = args.length === 1 ? args[0] : args[1] ?? 0;
+  const step = args[2] ?? 1;
 
   // Create a "target" object (that we'll use as proxy target)
   const target = {

--- a/src/range.ts
+++ b/src/range.ts
@@ -18,18 +18,19 @@ export function range(start: number, end: number, step: number): Range;
  */
 export function range(...args: number[]): Range {
   // Parse out start/end/step to handle overload
-  const [start, end, step] = (() => {
-    if (args.length === 0) {
-      throw new Error("range requires at least one argument");
-    }
-    if (args.length === 1) {
-      return [0, args[0], 1];
-    }
-    if (args.length === 2) {
-      return [args[0], args[1], 1];
-    }
-    return args.slice(0, 3);
-  })();
+  let start = 0,
+    end = 0,
+    step = 1;
+
+  if (args.length === 0) {
+    throw new Error("range requires at least one argument");
+  } else if (args.length === 1) {
+    end = args[0];
+  } else if (args.length === 2) {
+    [start, end] = args.slice(0, 2);
+  } else {
+    [start, end, step] = args.slice(0, 3);
+  }
 
   // Create a "target" object (that we'll use as proxy target)
   const target = {


### PR DESCRIPTION
Handle the `range()` case, if no args passed – should throw error.

Also removes an iife, so an extra function/scope doesn't have to be created.