### PR TITLE
Support for `.forEach` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Uses iterators (_not_ arrays) for iteration, so no unnecessary memory usage.
 - Uses `Proxy` to add some custom behavior, such as handling the `in` keyword (to test if a number is "in" the range) and adding functionality to look up range values by step (e.g., `range(2, 5)[1] === 3`).
 - Supports negative steps and non-integer start/end/step values.
+- Added `.forEach` method like `Array.prototype.forEach` for easier iteration.
 
 ## Installation and Basic Example
 
@@ -24,6 +25,9 @@ import { range } from 'smol-range';
 for (const x of range(12)) {
   // Do something with x
 }
+
+// Or using .forEach
+range(12).forEach(x => { /* ... */ });
 
 // Or maybe even generate an array from a range...
 const arr = Array.from(range(10, 20, 2)); // [10, 12, 14, 16, 18]

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ A generated Range has a `.forEach` method that allows you to easily iterate thro
 
 ```ts
 type Range = {
-	// ...
-	forEach: (fn: (x: number, i: number) => void) => void;
+  // ...
+  forEach: (fn: (x: number, i: number) => void) => void;
 }
 ```
 
@@ -150,11 +150,11 @@ You pass in a callback that can (optionally) accept a value (current iteration v
 
 ```ts
 range(2, 6).forEach(x => {
-	// x: 2, 3, 4, 6
+  // x: 2, 3, 4, 6
 });
 
 range(2, 6).forEach((x, i) => {
-	console.log(`${i}th call, current value is ${x}`);
+  console.log(`${i}th call, current value is ${x}`);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,29 @@ myRange[-5]; // -> undefined
 
 Again, the library uses **math** to determine these values, once again ensuring `O(1)` efficiency. 
 
+### Custom `.forEach` method
+
+A generated Range has a `.forEach` method that allows you to easily iterate through a range, similar to `Array.prototype.forEach`.
+
+```ts
+type Range = {
+	// ...
+	forEach: (fn: (x: number, i: number) => void) => void;
+}
+```
+
+You pass in a callback that can (optionally) accept a value (current iteration value from the range) and an iteration count (what step in the iteration currently on). Here's an example:
+
+```ts
+range(2, 6).forEach(x => {
+	// x: 2, 3, 4, 6
+});
+
+range(2, 6).forEach((x, i) => {
+	console.log(`${i}th call, current value is ${x}`);
+});
+```
+
 ## Non-integer values
 
 Non-integer values are fair game for start, end, and step values! E.g., there's nothing stopping you from doing something like `range(1.2, 7.4, 1.7)`. However, the `range` function generates values $y$ via this basic formula:

--- a/src/range.test.ts
+++ b/src/range.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { range } from "./range";
 
 describe("range", () => {
@@ -156,5 +156,32 @@ describe("range", () => {
       const r = range(5);
       r.start = 3;
     }).toThrow();
+  });
+
+  test(".forEach is called n times", () => {
+    const f = vi.fn();
+    range(5).forEach(f);
+
+    expect(f).toHaveBeenCalledTimes(5);
+    expect(f).toHaveBeenCalledWith(0, 0);
+    expect(f).toHaveBeenCalledWith(4, 4);
+    expect(f).not.toHaveBeenCalledWith(5);
+  });
+
+  test(".forEach is called with current range value, and iteration step", () => {
+    const f = vi.fn();
+    range(2, 20, 2).forEach(f);
+
+    expect(f).toHaveBeenCalledTimes(9);
+    expect(f).toHaveBeenCalledWith(2, 0);
+    expect(f).toHaveBeenCalledWith(4, 1);
+    expect(f).toHaveBeenCalledWith(18, 8);
+
+    const g = vi.fn();
+    range(30, 0, -3).forEach(g);
+
+    expect(g).toHaveBeenCalledWith(30, 0);
+    expect(g).toHaveBeenCalledWith(27, 1);
+    expect(g).toHaveBeenCalledWith(3, 9);
   });
 });

--- a/src/range.test.ts
+++ b/src/range.test.ts
@@ -184,4 +184,22 @@ describe("range", () => {
     expect(g).toHaveBeenCalledWith(27, 1);
     expect(g).toHaveBeenCalledWith(3, 9);
   });
+
+  test(".forEach throws on infinite start/end", () => {
+    expect(() => {
+      range(Infinity).forEach(() => null);
+    }).toThrow();
+
+    expect(() => {
+      range(0, Infinity).forEach(() => null);
+    }).toThrow();
+
+    expect(() => {
+      range(0, Infinity, 3).forEach(() => null);
+    }).toThrow();
+
+    expect(() => {
+      range(-Infinity, 0, -3).forEach(() => null);
+    }).toThrow();
+  });
 });

--- a/src/range.ts
+++ b/src/range.ts
@@ -4,7 +4,7 @@ type Range = {
   step: number;
   [Symbol.iterator](): Generator<number, void, unknown>;
   [i: number]: number | undefined;
-  forEach: (fn: (x: number) => void) => void;
+  forEach: (fn: (x: number, i: number) => void) => void;
 };
 
 /*

--- a/src/range.ts
+++ b/src/range.ts
@@ -52,6 +52,13 @@ export function range(...args: number[]): Range {
      * forEach method, similar to Array.prototype.forEach
      */
     forEach(fn: (x: number, i: number) => void) {
+      // If infinite start/end, throw error otherwise we'll end in infinite loop
+      if (!(Number.isFinite(start) && Number.isFinite(end))) {
+        throw new Error(
+          "Cannot call .forEach on range with infinite start/end"
+        );
+      }
+
       let i = 0;
       for (const x of this) {
         fn(x, i);

--- a/src/range.ts
+++ b/src/range.ts
@@ -4,6 +4,7 @@ type Range = {
   step: number;
   [Symbol.iterator](): Generator<number, void, unknown>;
   [i: number]: number | undefined;
+  forEach: (fn: (x: number) => void) => void;
 };
 
 /*
@@ -27,7 +28,7 @@ export function range(...args: number[]): Range {
   const step = args[2] ?? 1;
 
   // Create a "target" object (that we'll use as proxy target)
-  const target = {
+  const target: Range = {
     start,
     end,
     step,
@@ -44,6 +45,17 @@ export function range(...args: number[]): Range {
 
         i++;
         val = start + i * step;
+      }
+    },
+
+    /**
+     * forEach method, similar to Array.prototype.forEach
+     */
+    forEach(fn: (x: number, i: number) => void) {
+      let i = 0;
+      for (const x of this) {
+        fn(x, i);
+        i++;
       }
     },
   };


### PR DESCRIPTION
This PR adds support for a custom `.forEach` method to make iterating over the range even easier.